### PR TITLE
Add other OS support

### DIFF
--- a/Sharpii/Program.cs
+++ b/Sharpii/Program.cs
@@ -34,7 +34,7 @@ namespace Sharpii
                 Environment.Exit(0);
             }
 
-            if (!File.Exists(Path.GetDirectoryName(Application.ExecutablePath) + "\\libWiiSharp.dll"))
+            if (!File.Exists(Path.GetDirectoryName(Application.ExecutablePath) + Path.DirectorySeparatorChar + "libWiiSharp.dll"))
             {
                 Console.WriteLine("ERROR: libWiiSharp.dll not found");
                 Console.WriteLine("\n\nAttemp to download? [Y/N]");


### PR DESCRIPTION
We over at @RiiConnect24 have been using Sharpii for a while and have encountered repeatedly an issue where the application attempted to download `<folder above>\libWiiSharp.dll` instead of using the one in the current directory. By using a System.IO implementation, we can per-system figure out the file path.